### PR TITLE
FIX: clarify format() and f-strings

### DIFF
--- a/lectures/python_essentials.md
+++ b/lectures/python_essentials.md
@@ -468,7 +468,7 @@ for line in data_file:
 data_file.close()
 ```
 
-Here `format()` is a string method [used for inserting variables into strings](https://docs.python.org/3/library/string.html#formatspec).
+Here `f'` is an f-string [used for inserting variables into strings](https://docs.python.org/3/library/string.html#formatspec).
 
 The reformatting of each line is the result of three different string methods,
 the details of which can be left till later.


### PR DESCRIPTION
This clarifies the use of `f-string` instead of the current note using `format`. 

Thank you @jaeyungkim  for opening #354 