### PR TITLE
ENH: migrate to QE AI link-checker

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: gh-pages
       - name: AI-Powered Link Checker
-        uses: QuantEcon/meta/.github/actions/link-checker@main
+        uses: QuantEcon/meta/.github/actions/link-checker@copilot/fix-195
         with:
           html-path: '.'            # gh-pages live html
           fail-on-broken: 'false'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: gh-pages
       - name: AI-Powered Link Checker
-        uses: QuantEcon/meta/.github/actions/link-checker@copilot/fix-195
+        uses: QuantEcon/meta/.github/actions/link-checker@main
         with:
           html-path: '.'            # gh-pages live html
           fail-on-broken: 'false'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -6,26 +6,21 @@ on:
   workflow_dispatch:
 jobs:
   link-checking:
-    name: Link Checking
+    name: QuantEcon AI link checking
     runs-on: "ubuntu-latest"
     permissions:
-      issues: write # required for peter-evans/create-issue-from-file
+      issues: write   # required for QuantEcon link-checker
     steps:
       # Checkout the live site (html)
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: gh-pages
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v2
+      - name: AI-Powered Link Checker
+        uses: QuantEcon/meta/.github/actions/link-checker@main
         with:
-          fail: false
-          args: --accept 403,503 *.html
-      - name: Create Issue From File
-        if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v5
-        with:
-          title: Link Checker Report
-          content-filepath: ./lychee/out.md
-          labels: report, automated issue, linkchecker
+          html-path: '.'            # gh-pages live html
+          fail-on-broken: 'false'
+          silent-codes: '403,503'
+          ai-suggestions: 'true'
+          create-issue: 'true'


### PR DESCRIPTION
This PR enables the QuantEcon [AI enabled link-checker action](https://github.com/QuantEcon/meta/pull/196) which replaces `lychee`. This is currently programmed to run weekly over the live site hosted in `gh-pages` -- it will report any issues found as an Issue. 

We have done extensive testing (see #389), but we will use this repo as a test case for another week before pushing this across our lectures. 