### PR TITLE
MAINT: upgrade to quantecon-book-theme==0.9.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.8.3
+    - quantecon-book-theme==0.9.1
     - sphinx-tojupyter==0.3.1
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.0.1


### PR DESCRIPTION
This PR updates `quantecon-book-theme==0.9.1` which addresses #409 