### PR TITLE
Upgrade quantecon-book-theme to 0.12.0 with git metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v11
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v11
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v11
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch full git history for changelog feature
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch full git history for changelog feature
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.11.0
+    - quantecon-book-theme==0.12.0
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -41,6 +41,7 @@ sphinx:
       header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-programming.myst
       nb_repository_url: https://github.com/QuantEcon/lecture-python-programming.notebooks
+      path_to_docs: lectures
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png


### PR DESCRIPTION
This PR upgrades quantecon-book-theme from 0.11.0 to 0.12.0, which includes:

## New Features in 0.12.0
- Improved lecture header layout with git-based metadata
- Last changed timestamp showing the date of the most recent commit
- Commit history dropdown showing the last 10 commits
- Clickable commit hashes linking directly to GitHub
- Full commit history link for complete version tracking

## Configuration Changes
- Added `path_to_docs: lectures` to enable proper GitHub links to source files

The CI build will provide a preview of the new theme features before merging.

Release: https://github.com/QuantEcon/quantecon-book-theme/releases/tag/v0.12.0