### PR TITLE
MAINT: Add RunsOn configuration file

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,6 @@
+images:
+  quantecon_ubuntu2404:
+    platform: "linux"
+    arch: "x64"
+    ami: "ami-0edec81935264b6d3"
+    region: "us-west-2"


### PR DESCRIPTION
## Summary

This PR adds the RunsOn configuration file (`.github/runs-on.yml`) which must be present on the main branch for RunsOn to recognize custom AMI images.

## Why This Is Needed First

RunsOn reads the `runs-on.yml` configuration from the **default branch** (main) to identify custom images. This file needs to be merged before PR #437 can be tested.

## Configuration

```yaml
images:
  quantecon_ubuntu2404:
    platform: "linux"
    arch: "x64"
    ami: "ami-0edec81935264b6d3"
    region: "us-west-2"
```

This uses the same QuantEcon Ubuntu 24.04 AMI that is used in [lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst).

## Related

- Prerequisite for PR #437 (Enable RunsOn GPU support for lecture builds)