### PR TITLE
MAINT: Update quantecon-book-theme 0.12.0 -> 0.13.2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==1.0.4post1
-    - quantecon-book-theme==0.12.0
+    - quantecon-book-theme==0.13.2
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==1.2.1


### PR DESCRIPTION
Updates `quantecon-book-theme` to the latest version (0.13.2).

## Changes
- `quantecon-book-theme`: 0.12.0 → 0.13.2

## Release Notes
See https://github.com/QuantEcon/quantecon-book-theme/releases for changelog.