### PR TITLE
Add pip ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
       prefix: ⬆️
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    commit-message:
+      prefix: ⬆️
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "jupyter-book"
+        versions: [">=2.0"]


### PR DESCRIPTION
## Overview

Configures dependabot to also update PyPI packages in `environment.yml` in addition to GitHub Actions.

## Changes

- Added `pip` package ecosystem to dependabot configuration
- Added ignore rule to keep `jupyter-book < 2.0` (required until JB2 migration)

## Configuration

```yaml
- package-ecosystem: pip
  directory: /
  commit-message:
    prefix: ⬆️
  schedule:
    interval: weekly
  ignore:
    - dependency-name: "jupyter-book"
      versions: [">=2.0"]
```

This will help keep dependencies up-to-date automatically while respecting the jupyter-book version constraint.