### PR TITLE
Add centralized GPU admonition for JAX lectures

### DIFF
--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,7 +1,7 @@
 ```{admonition} GPU
 :class: warning
 
-This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and target JAX for GPU programming.
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and targets JAX for GPU programming.
 
 Free GPUs are available on Google Colab.
 To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.

--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,0 +1,11 @@
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and target JAX for GPU programming.
+
+Free GPUs are available on Google Colab.
+To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support.
+If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```

--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,11 +1,5 @@
 ```{admonition} GPU
 :class: warning
 
-This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and targets JAX for GPU programming.
-
-Free GPUs are available on Google Colab.
-To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
-
-Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support.
-If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+This lecture is designed to run on a GPU. To use Google Colab's free GPUs, click the play icon top right, select Colab, and set the runtime to include a GPU. For local GPU setup, see the [JAX installation guide](https://github.com/google/jax).
 ```

--- a/lectures/jax_intro.md
+++ b/lectures/jax_intro.md
@@ -33,16 +33,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 !pip install jax quantecon
 ```
 
-```{admonition} GPU
-:class: warning
-
-This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and target JAX for GPU programming.
-
-Free GPUs are available on Google Colab.
-To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
-
-Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support.
-If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```{include} _admonition/gpu.md
 ```
 
 ## JAX as a NumPy Replacement

--- a/lectures/numpy_vs_numba_vs_jax.md
+++ b/lectures/numpy_vs_numba_vs_jax.md
@@ -48,16 +48,7 @@ tags: [hide-output]
 !pip install quantecon jax
 ```
 
-```{admonition} GPU
-:class: warning
-
-This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and target JAX for GPU programming.
-
-Free GPUs are available on Google Colab.
-To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
-
-Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support.
-If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```{include} _admonition/gpu.md
 ```
 
 We will use the following imports.


### PR DESCRIPTION
## Summary

This PR adds a centralized GPU admonition file that can be included in all JAX-related lectures, making it easier to maintain consistent notices across the repository.

## Changes

1. **New file: `lectures/_admonition/gpu.md`**
   - Contains the standard GPU admonition text
   - Can be updated in one place to affect all JAX lectures

2. **Updated `jax_intro.md`**
   - Replaced inline GPU admonition with `{include} _admonition/gpu.md`

3. **Updated `numpy_vs_numba_vs_jax.md`**
   - Replaced inline GPU admonition with `{include} _admonition/gpu.md`

## GPU Admonition Content

The new simplified admonition:

```
This lecture is designed to run on a GPU. To use Google Colab's free GPUs, 
click the play icon top right, select Colab, and set the runtime to include a 
GPU. For local GPU setup, see the JAX installation guide.
```

## Benefits

- Single source of truth for GPU notice content
- Easier to update wording across all lectures
- Consistent with approach used in `lecture-python.myst` and `lecture-jax`
- Simplified, more concise messaging