### PR TITLE
⬆️ Configure dependabot to ignore Python version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
     ignore:
       - dependency-name: "jupyter-book"
         versions: [">=2.0"]
+      - dependency-name: "python"
+        # Python version should be constrained by the anaconda distribution version


### PR DESCRIPTION
Python version should be constrained by the anaconda distribution version specified in environment.yml, not updated independently by dependabot.

This prevents dependabot from opening PRs like #455 that attempt to update the Python version independently of the anaconda distribution.