### PR TITLE
Fix/dependabot ignore python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
     ignore:
       - dependency-name: "jupyter-book"
         versions: [">=2.0"]
+      - dependency-name: "python"
+        # Python version should be constrained by the anaconda distribution version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,4 @@ updates:
         versions: [">=2.0"]
       - dependency-name: "python"
         # Python version should be constrained by the anaconda distribution version
+        versions: [">0"]


### PR DESCRIPTION
Updates dependabot config to correctly ignore python version updates. Will be handled when anaconda is updated