### PR TITLE
Update GPU admonition to clarify lectures run on CPUs

### DIFF
--- a/lectures/_admonition/gpu.md
+++ b/lectures/_admonition/gpu.md
@@ -1,7 +1,7 @@
 ```{admonition} GPU
 :class: warning
 
-This lecture was built using a machine with access to a GPU.
+This lecture was built using a machine with access to a GPU --- although it will also run without one.
 
 [Google Colab](https://colab.research.google.com/) has a free tier with GPUs
 that you can access as follows:


### PR DESCRIPTION
This PR updates the GPU admonition message to clarify that lectures will run without a GPU.

**Changes:**
- Modified `lectures/_admonition/gpu.md` to add "--- although it will also run without one" to the first line
- Incorporates feedback from @jstac
- Harmonizes messaging across lecture repositories

**Impact:**
This provides clearer guidance to users who may not have access to a GPU, ensuring they understand the lectures are still accessible to them.