### PR TITLE
TEST: Switch to new quantecon-sphinx-theme (Theme #2) + collect Feedback

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme==0.15.1
+    - quantecon-sphinx-theme @ git+https://github.com/QuantEcon/quantecon-sphinx-theme.git@main
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -31,31 +31,22 @@ sphinx:
     # sphinx-exercise
     exercise_style: "solution_follow_exercise"
     html_favicon: _static/lectures-favicon.ico
-    html_theme: quantecon_book_theme
+    html_theme: quantecon_sphinx_theme
     html_static_path: ['_static']
     html_theme_options:
-      authors:
-        - name: Thomas J. Sargent
-          url: http://www.tomsargent.com/
-        - name: John Stachurski
-          url: https://johnstachurski.net/      
+      color_scheme: default
+      dark_mode: auto
+      toc_sticky: true
+      toc_autoexpand: true
       dark_logo: quantecon-logo-transparent.png
-      header_organisation_url: https://quantecon.org
-      header_organisation: QuantEcon
       repository_url: https://github.com/QuantEcon/lecture-python-programming.myst
-      nb_repository_url: https://github.com/QuantEcon/lecture-python-programming.notebooks
+      repository_branch: main
       path_to_docs: lectures
-      twitter: quantecon
-      twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
-      og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
+      use_repository_button: true
       description: This website presents a set of lectures on python programming for economics, designed and written by Thomas J. Sargent and John Stachurski.
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
-      analytics:
-        google_analytics_id: G-X7DH1M2DPY
-      launch_buttons:
-        notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
-        colab_url                 : https://colab.research.google.com
-        thebe                     : false  # Add a thebe button to pages (requires the repository to run on Binder)
+      og_image: https://assets.quantecon.org/img/qe-og-logo.png
+      twitter_handle: quantecon
     intersphinx_mapping: 
       jax: 
         - "https://jax.quantecon.org/"


### PR DESCRIPTION
## Test PR: New QuantEcon Sphinx Theme

This PR replaces `quantecon-book-theme` with the new [`quantecon-sphinx-theme`](https://github.com/QuantEcon/quantecon-sphinx-theme).

### Changes

- **environment.yml**: Replaced `quantecon-book-theme==0.15.1` with `quantecon-sphinx-theme` installed from the git main branch
- **lectures/_config.yml**: 
  - Changed `html_theme` from `quantecon_book_theme` to `quantecon_sphinx_theme`
  - Updated `html_theme_options` to use the new theme's configuration schema (color_scheme, dark_mode, toc_sticky, toc_autoexpand, etc.)
  - Removed old book-theme-specific options (authors, header_organisation, analytics, launch_buttons)

### Purpose

This is a **test PR** to evaluate the new theme's rendering with our lecture content. Review the CI build output to assess compatibility.

> **DO NOT MERGE** — This is for testing/evaluation only.
