### PR TITLE
Update quantecon-book-theme to 0.18.0 and enable sticky_contents

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book>=1.0.4post1,<2.0
-    - quantecon-book-theme==0.17.1
+    - quantecon-book-theme==0.18.0
     - sphinx-tojupyter==0.6.0
     - sphinxext-rediraffe==0.3.0
     - sphinx-exercise==1.2.1

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -52,6 +52,7 @@ sphinx:
       keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       analytics:
         google_analytics_id: G-X7DH1M2DPY
+      sticky_contents: true
       launch_buttons:
         notebook_interface        : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
         colab_url                 : https://colab.research.google.com


### PR DESCRIPTION
## Changes

- Bump `quantecon-book-theme` from 0.17.1 to 0.18.0 in `environment.yml`
- Enable `sticky_contents: true` in `html_theme_options` in `_config.yml` for a sticky right-hand side contents menu

Reference: aligned with [lecture-python.myst](https://github.com/QuantEcon/lecture-python.myst) configuration.