### PR TITLE
Prepare for repo rename: drop .myst suffix

### DIFF
--- a/_notebook_repo/README.md
+++ b/_notebook_repo/README.md
@@ -4,4 +4,4 @@
 
 Notebooks for https://python-programming.quantecon.org
 
-**Note:** This README should be edited [here](https://github.com/quantecon/lecture-python-programming.myst/.binder)
+**Note:** This README should be edited [here](https://github.com/quantecon/lecture-python-programming/.binder)

--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -42,7 +42,7 @@ sphinx:
       dark_logo: quantecon-logo-transparent.png
       header_organisation_url: https://quantecon.org
       header_organisation: QuantEcon
-      repository_url: https://github.com/QuantEcon/lecture-python-programming.myst
+      repository_url: https://github.com/QuantEcon/lecture-python-programming
       nb_repository_url: https://github.com/QuantEcon/lecture-python-programming.notebooks
       path_to_docs: lectures
       twitter: quantecon


### PR DESCRIPTION
## Summary

Prepares for renaming this repository from `lecture-python-programming.myst` to `lecture-python-programming` by updating the two internal references to the repo name.

## Changes

- `lectures/_config.yml` — `repository_url` updated (used by the Jupyter Book theme for "Edit on GitHub" links)
- `_notebook_repo/README.md` — link to `.binder` directory updated

## What's unaffected

- **GitHub Pages**: The site uses a custom domain (`python-programming.quantecon.org`) via CNAME, so the rename has no effect on the published site.
- **Existing links**: GitHub automatically redirects all URLs from the old name to the new name (git clone, web, API).
- **Workflows**: `publish.yml` references `lecture-python-programming.notebooks` (a separate repo) and uses base filenames without `.myst` — no changes needed.
- **`nb_repository_url`**: Points to the `.notebooks` repo, which is a different repository and unaffected.

## After merging

1. Go to **Settings → General → Repository name**
2. Change `lecture-python-programming.myst` → `lecture-python-programming`
3. Update local clones: `git remote set-url origin git@github.com:QuantEcon/lecture-python-programming.git`
