### PR TITLE
[translation] Add Farsi (fa) translation sync workflow

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -1,0 +1,30 @@
+# Sync Translations — Farsi
+# On merged PR, translate changed lectures into the Farsi target repo.
+name: Sync Translations (Farsi)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - '_toc.yml'
+
+jobs:
+  sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0.10.0
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-python-programming.fa
+          target-language: fa
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}

--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
     paths:
       - 'lectures/**/*.md'
-      - '_toc.yml'
+      - 'lectures/_toc.yml'
 
 jobs:
   sync:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.10.0
+      - uses: QuantEcon/action-translation@v0.11.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa


### PR DESCRIPTION
## Summary

Adds the sync workflow for automated Farsi translation via [action-translation](https://github.com/QuantEcon/action-translation) v0.10.0.

## What it does

When a PR merges that touches `lectures/**/*.md` or `lectures/_toc.yml`:
1. The workflow detects which sections changed
2. Only the changed sections are translated (not the entire file)
3. A translation PR is automatically created in [lecture-python-programming.fa](https://github.com/QuantEcon/lecture-python-programming.fa)

## Requirements

- `ANTHROPIC_API_KEY` secret — for Claude translation API calls
- `QUANTECON_SERVICES_PAT` secret — for cross-repo write access to the `.fa` repo

## Related

- Target repo setup PR: https://github.com/QuantEcon/lecture-python-programming.fa/pull/67
