### PR TITLE
Add zh-cn sync workflow + bump fa to v0.11.1

### DIFF
--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -1,6 +1,6 @@
-# Sync Translations — Farsi
-# On merged PR, translate changed lectures into the Farsi target repo.
-name: Sync Translations (Farsi)
+# Sync Translations — Simplified Chinese
+# On merged PR, translate changed lectures into the zh-cn target repo.
+name: Sync Translations (Simplified Chinese)
 
 on:
   pull_request:
@@ -22,8 +22,8 @@ jobs:
       - uses: QuantEcon/action-translation@v0.11.1
         with:
           mode: sync
-          target-repo: QuantEcon/lecture-python-programming.fa
-          target-language: fa
+          target-repo: QuantEcon/lecture-python-programming.zh-cn
+          target-language: zh-cn
           source-language: en
           docs-folder: lectures
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Add the sync workflow for Simplified Chinese (zh-cn) translations targeting `QuantEcon/lecture-python-programming.zh-cn`.

Also bumps the Farsi sync workflow from `v0.11.0` → `v0.11.1` (model preservation fix).

**Changes:**
- New: `.github/workflows/sync-translations-zh-cn.yml` — triggers on merged PRs that touch `lectures/**/*.md` or `lectures/_toc.yml`
- Updated: `.github/workflows/sync-translations-fa.yml` — `v0.11.0` → `v0.11.1`

**Prerequisites:** The target repo already exists with 25 translated lectures from `translate init`.
