### PR TITLE
ci: bump action-translation v0.11.1 → v0.11.2

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.11.1
+      - uses: QuantEcon/action-translation@v0.11.2
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.11.1
+      - uses: QuantEcon/action-translation@v0.11.2
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `action-translation` from v0.11.1 → v0.11.2 in both sync workflow files.

### What's fixed

v0.11.2 fixes the parser crash when files have MyST cross-reference targets (`(label)=`) or directive blocks (e.g. `` ```{raw} jupyter`` ``) before the `# title` heading — the exact issue that caused the sync failures on PR #488 for both `fa` and `zh-cn` targets.

**Release**: https://github.com/QuantEcon/action-translation/releases/tag/v0.11.2

### Files changed
- `.github/workflows/sync-translations-fa.yml`
- `.github/workflows/sync-translations-zh-cn.yml`
