### PR TITLE
Fix broken raw GitHub URLs for CSV data files

### DIFF
--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -168,7 +168,7 @@ The dataset contains the following indicators
 We'll read this in from a URL using the `pandas` function `read_csv`.
 
 ```{code-cell} ipython3
-df = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/master/source/_static/lecture_specific/pandas/data/test_pwt.csv')
+df = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas/data/test_pwt.csv')
 type(df)
 ```
 

--- a/lectures/python_advanced_features.md
+++ b/lectures/python_advanced_features.md
@@ -1068,7 +1068,7 @@ In summary, iterables
 :label: paf_ex1
 ```
 
-Complete the following code, and test it using [this csv file](https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/master/source/_static/lecture_specific/python_advanced_features/test_table.csv), which we assume that you've put in your current working directory
+Complete the following code, and test it using [this csv file](https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/python_advanced_features/test_table.csv), which we assume that you've put in your current working directory
 
 ```{code-block} python3
 :class: no-execute


### PR DESCRIPTION
## Problem

The cache build is failing because `pandas.md` tries to fetch `test_pwt.csv` from a URL that no longer exists:

```
https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/master/source/_static/...
```

This returns **404** because the repo was restructured (the `.myst` suffix was dropped and `master` became `main`, `source/_static` became `lectures/_static`).

**Failed run:** https://github.com/QuantEcon/lecture-python-programming/actions/runs/23420771220/job/68125163471

## Fix

Updated two broken `raw.githubusercontent.com` URLs from the old path to the current one:

| File | Description |
|------|-------------|
| `lectures/pandas.md` | `test_pwt.csv` URL — **this causes the cache build failure** |
| `lectures/python_advanced_features.md` | `test_table.csv` URL — also broken (404) |

Old pattern: `master/source/_static/lecture_specific/...`
New pattern: `main/lectures/_static/lecture_specific/...`

Both updated URLs have been verified to return HTTP 200.
