### PR TITLE
feat: add \translate-resync support to sync workflows

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.11.2
+      - uses: QuantEcon/action-translation@v0.12.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -1,5 +1,6 @@
 # Sync Translations — Farsi
 # On merged PR, translate changed lectures into the Farsi target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
 name: Sync Translations (Farsi)
 
 on:
@@ -8,10 +9,14 @@ on:
     paths:
       - 'lectures/**/*.md'
       - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
 
 jobs:
   sync:
-    if: github.event.pull_request.merged == true
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -1,5 +1,6 @@
 # Sync Translations — Simplified Chinese
 # On merged PR, translate changed lectures into the zh-cn target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
 name: Sync Translations (Simplified Chinese)
 
 on:
@@ -8,10 +9,14 @@ on:
     paths:
       - 'lectures/**/*.md'
       - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
 
 jobs:
   sync:
-    if: github.event.pull_request.merged == true
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.11.2
+      - uses: QuantEcon/action-translation@v0.12.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
## Summary

Adds `issue_comment` trigger to both sync-translation workflows and bumps to `action-translation@v0.12.0` to enable the full sync notification feature set from [QuantEcon/action-translation v0.12.0](https://github.com/QuantEcon/action-translation/releases/tag/v0.12.0).

### What this enables

- **`\translate-resync` command**: Comment `\translate-resync` on a merged PR to re-trigger sync — no need to re-open PRs or create dummy commits
- **Success comments**: Successful syncs post a confirmation comment on the source PR with translation PR link
- **Failure issues**: Failed syncs auto-open a GitHub Issue with error details and recovery instructions

### Changes

- `.github/workflows/sync-translations-fa.yml` — added `issue_comment: [created]` trigger, updated `if` condition, bumped to `@v0.12.0`
- `.github/workflows/sync-translations-zh-cn.yml` — same
