### PR TITLE
ci: bump action-translation to v0.12.1

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.0
+      - uses: QuantEcon/action-translation@v0.12.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.0
+      - uses: QuantEcon/action-translation@v0.12.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `action-translation` from v0.12.0 to v0.12.1 in both zh-cn and fa sync workflows.

Changes in v0.12.1: bug fixes for heading-map handling, pre-title content, and section reconstruction.