### PR TITLE
ci: bump action-translation to v0.12.2

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.1
+      - uses: QuantEcon/action-translation@v0.12.2
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.1
+      - uses: QuantEcon/action-translation@v0.12.2
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `action-translation` from v0.12.1 to v0.12.2 in both translation sync workflows.

**Fixes in v0.12.2:**
- Position fallback guard for mismatched section counts (prevents wrong heading-map values)
- Resync uses PR merge commit SHA (makes `\translate-resync` work correctly)

Release notes: https://github.com/QuantEcon/action-translation/releases/tag/v0.12.2

Part of #495
