### PR TITLE
chore: bump action-translation v0.12.2 → v0.12.3

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.2
+      - uses: QuantEcon/action-translation@v0.12.3
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.2
+      - uses: QuantEcon/action-translation@v0.12.3
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `action-translation` from v0.12.2 → v0.12.3 in both sync workflows.

## Changes
- `sync-translations-zh-cn.yml`: `@v0.12.2` → `@v0.12.3`
- `sync-translations-fa.yml`: `@v0.12.2` → `@v0.12.3`

## What's new in v0.12.3
Fixes QuantEcon/action-translation#45 — translation PRs are now scoped to the source PR's actual changes.

Previously, when multiple source PRs were merged before their translation PRs were merged, each new translation PR would accumulate all unmerged content from earlier PRs (superset problem). Now, unchanged sections missing from the target are skipped, and Git's 3-way merge combines the PRs when they're merged independently.

See [release notes](https://github.com/QuantEcon/action-translation/releases/tag/v0.12.3) for full details.
