### PR TITLE
ci: bump action-translation to v0.12.4

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.3
+      - uses: QuantEcon/action-translation@v0.12.4
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.3
+      - uses: QuantEcon/action-translation@v0.12.4
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `action-translation` from v0.12.3 → v0.12.4 in both sync workflows (zh-cn, fa).

### Changes in [v0.12.4](https://github.com/QuantEcon/action-translation/releases/tag/v0.12.4)
- **CJK–MyST spacing rule for zh-cn**: Ensures proper spacing between Chinese text and MyST directives
- **MyST target-label blank-line cleanup**: Fixes blank lines between target labels and headings