### PR TITLE
chore: bump action-translation to v0.13.0

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.4
+      - uses: QuantEcon/action-translation@v0.13.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.12.4
+      - uses: QuantEcon/action-translation@v0.13.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Bump `QuantEcon/action-translation` from v0.12.4 to v0.13.0 in both sync workflows.

### What changed in v0.13.0
- **Translation frontmatter**: Replaced flat `heading-map:` YAML block with structured `translation: { title, headings }` format
- Backward compatible — reads both old and new formats
- Target repos (zh-cn, fa) already migrated

### Files changed
- `.github/workflows/sync-translations-zh-cn.yml`
- `.github/workflows/sync-translations-fa.yml`

Release: https://github.com/QuantEcon/action-translation/releases/tag/v0.13.0