### PR TITLE
[python_essentials.md] Update np.random → Generator API

### DIFF
--- a/lectures/python_essentials.md
+++ b/lectures/python_essentials.md
@@ -1068,10 +1068,11 @@ code.
 ```{code-cell} python3
 import numpy as np
 
+rng = np.random.default_rng()
 n = 100
 ϵ_values = []
 for i in range(n):
-    e = np.random.randn()
+    e = rng.standard_normal()
     ϵ_values.append(e)
 ```
 
@@ -1085,8 +1086,9 @@ for i in range(n):
 Here's one solution.
 
 ```{code-cell} python3
+rng = np.random.default_rng()
 n = 100
-ϵ_values = [np.random.randn() for i in range(n)]
+ϵ_values = [rng.standard_normal() for i in range(n)]
 ```
 
 ```{solution-end}


### PR DESCRIPTION
This PR updates `lectures/python_essentials.md` as part of the Numpy random API migration described in https://github.com/QuantEcon/meta/issues/299.


**Changes made:**
- Replaced `np.random.randn()` with `rng.standard_normal()`.
- Added `rng = np.random.default_rng()` in both the exercise block and the corresponding solution block.

The changes are small and straightforward.
When you have time, I would be grateful if you could take a look.