### PR TITLE
[need_for_speed.md] Update np.random → Generator API

### DIFF
--- a/lectures/need_for_speed.md
+++ b/lectures/need_for_speed.md
@@ -340,8 +340,9 @@ The following vectorized code uses NumPy, which we'll soon investigate in depth,
 to achieve the same thing.
 
 ```{code-cell} ipython
+rng = np.random.default_rng()
 with qe.Timer():
-    x = np.random.uniform(0, 1, n)
+    x = rng.uniform(0, 1, n)
     y = np.sum(x**2)
 ```
 


### PR DESCRIPTION
This PR updates `lectures/need_for_speed.md` as part of the NumPy random API migration described in https://github.com/QuantEcon/meta/issues/299.

The change is limited to one remaining legacy NumPy random API usage in the vectorized NumPy example ("9.4.2. Vectorization vs pure Python loops").

The `rng` generator is initialized outside the `with qe.Timer():` block, so the timing comparison continues to measure only the vectorized NumPy operation itself.

I also checked the rendered lecture with a local build. The relative timing difference between the non-vectorized Python loop and the vectorized NumPy version remains essentially unchanged, so the speed comparison in the lecture is not affected by this update.

@HumphreyYang, I'd be grateful if you could take a look when you have time!