### PR TITLE
[scipy.md] Update np.random → Generator API

### DIFF
--- a/lectures/scipy.md
+++ b/lectures/scipy.md
@@ -104,10 +104,11 @@ The `scipy.stats` subpackage supplies
 
 ### Random Variables and Distributions
 
-Recall that `numpy.random` provides functions for generating random variables
+Recall that `numpy.random` provides tools for generating random variables
 
 ```{code-cell} python3
-np.random.beta(5, 5, size=3)
+rng = np.random.default_rng()
+rng.beta(5, 5, size=3)
 ```
 
 This generates a draw from the distribution with the density function below when `a, b = 5, 5`
@@ -188,8 +189,9 @@ For example, `scipy.stats.linregress` implements simple linear regression
 ```{code-cell} python3
 from scipy.stats import linregress
 
-x = np.random.randn(200)
-y = 2 * x + 0.1 * np.random.randn(200)
+rng = np.random.default_rng()
+x = rng.standard_normal(200)
+y = 2 * x + 0.1 * rng.standard_normal(200)
 gradient, intercept, r_value, p_value, std_err = linregress(x, y)
 gradient, intercept
 ```
@@ -572,8 +574,9 @@ Set `M = 10_000_000`
 Here is one solution:
 
 ```{code-cell} ipython3
+rng = np.random.default_rng()
 M = 10_000_000
-S = np.exp(μ + σ * np.random.randn(M))
+S = np.exp(μ + σ * rng.standard_normal(M))
 return_draws = np.maximum(S - K, 0)
 P = β**n * np.mean(return_draws) 
 print(f"The Monte Carlo option price is {P:3f}")

--- a/lectures/scipy.md
+++ b/lectures/scipy.md
@@ -189,7 +189,6 @@ For example, `scipy.stats.linregress` implements simple linear regression
 ```{code-cell} python3
 from scipy.stats import linregress
 
-rng = np.random.default_rng()
 x = rng.standard_normal(200)
 y = 2 * x + 0.1 * rng.standard_normal(200)
 gradient, intercept, r_value, p_value, std_err = linregress(x, y)


### PR DESCRIPTION
  ## Summary

This PR updates `lectures/scipy.md` as part of the NumPy random API migration described in https://github.com/QuantEcon/meta/issues/299.

The changes are limited to the following:

  - Replace `np.random.beta(...)` with `rng = np.random.default_rng()` / `rng.beta(...)`
  - Update the surrounding wording: "functions" → "tools" to avoid implying module-level functions
  - Replace `np.random.randn(...)` with `rng.standard_normal(...)` in "12.3.3. Other Goodies in scipy.stats"
  - Replace `np.random.randn(...)` with `rng.standard_normal(...)` in the Monte Carlo exercise solution (Exercise 12.3)

  Each code block defines its own `rng` locally. The exercise solution block remains self-contained.
  No fixed seed is introduced, as the original lecture did not use one.
  No Numba-related code was present in this file.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
