### PR TITLE
[about_py.md] Update np.random → Generator API

### DIFF
--- a/lectures/about_py.md
+++ b/lectures/about_py.md
@@ -464,10 +464,10 @@ Here's some example code that generates and plots a random graph, with node colo
 ```{code-cell} ipython
 import networkx as nx
 import matplotlib.pyplot as plt
-np.random.seed(1234)
+rng = np.random.default_rng(1234)
 
 # Generate a random graph
-p = dict((i, (np.random.uniform(0, 1), np.random.uniform(0, 1)))
+p = dict((i, (rng.uniform(0, 1), rng.uniform(0, 1)))
          for i in range(200))
 g = nx.random_geometric_graph(200, 0.12, pos=p)
 pos = nx.get_node_attributes(g, 'pos')


### PR DESCRIPTION
## Summary

Migrate `lectures/about_py.md` to the NumPy Generator API as part of [QuantEcon/meta#299](https://github.com/QuantEcon/meta/issues/299).

- Replace `np.random.seed(1234)` with `rng = np.random.default_rng(1234)` and update the two `np.random.uniform` calls to `rng.uniform` in the NetworkX graph example.
- The fixed seed is preserved because the original lecture already used one.
- No surrounding prose changes were required.
- No Numba-related code is present in this file.

Hi @mmcky and @HumphreyYang, I'd be grateful if you could take a look when you have time.
