### PR TITLE
RunsOn v3: switch disk=large → volume=80gb

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     steps:
       - uses: actions/checkout@v6
       - name: Setup Anaconda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Migrate the RunsOn self-hosted runner labels from the v2 `disk=large` sizing to the v3 `volume=80gb` form across all three RunsOn workflows (`ci`, `cache`, `publish`). `family=` and `image=` are unchanged.

This must merge **together with** this repo's move from the v2 to the v3 RunsOn GitHub App — v2 does not understand `volume=`, and a v3 runner left on `disk=large` boots the image's default root volume (GPU jobs can then hit "no space left on device"). The app move (add to v3 / remove from v2) is already done; opening this PR exercises `ci` on the v3 stack.

Part of QuantEcon/lectures#5
See QuantEcon/meta#322