### PR TITLE
Adopt quantecon/actions/publish-gh-pages for GitHub Pages deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -101,43 +101,16 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ -n -W --keep-going
-      # Create HTML archive for release assets
-      - name: Create HTML archive
-        shell: bash -l {0}
-        run: |
-          tar -czf lecture-python-programming-html-${{ github.ref_name }}.tar.gz -C _build/html .
-          sha256sum lecture-python-programming-html-${{ github.ref_name }}.tar.gz > html-checksum.txt
-
-          # Create metadata manifest
-          cat > html-manifest.json << EOF
-          {
-            "tag": "${{ github.ref_name }}",
-            "commit": "${{ github.sha }}",
-            "timestamp": "$(date -Iseconds)",
-            "size_mb": $(du -sm _build/html | cut -f1),
-            "file_count": $(find _build/html -type f | wc -l)
-          }
-          EOF
-      - name: Upload archives to release
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            lecture-python-programming-html-${{ github.ref_name }}.tar.gz
-            html-checksum.txt
-            html-manifest.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add CNAME for custom domain
-        run: echo "python-programming.quantecon.org" > _build/html/CNAME
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _build/html/
+      # Deploy to GitHub Pages + publish release assets (html archive, checksum, manifest)
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: quantecon/actions/publish-gh-pages@v0.8.0
+        with:
+          build-dir: _build/html
+          cname: python-programming.quantecon.org
+          create-release-assets: 'true'
+          asset-name: 'lecture-python-programming-html'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare lecture-python-programming.notebooks sync
         shell: bash -l {0}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page-url }}
+      url: ${{ steps.deployment.outputs['page-url'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Migrates the GitHub Pages deploy to `quantecon/actions/publish-gh-pages@v0.8.0`, bringing this repo onto the same publish action as the rest of the lecture family. Part of the standardization tracked in QuantEcon/lectures#11.

## What changed

One composite step replaces six hand-rolled steps — the inline release-asset packaging (`tar` + `sha256sum` + `manifest.json` → `softprops/action-gh-release`) and the native Pages deploy (`configure-pages` → `upload-pages-artifact` → `deploy-pages`):

- `uses: quantecon/actions/publish-gh-pages@v0.8.0` with `build-dir`, `cname: python-programming.quantecon.org`, `create-release-assets: 'true'`, `asset-name`, `github-token`.
- `environment.url` now reads the composite's output name (`page-url`).

## Scope — deploy only, no build change

The `jb build` steps (nitpick flags intact), the PDF/notebook asset builds, and the notebook sync to `lecture-python-programming.notebooks` are untouched. This is the same deploy-step swap the five composite repos already run in production, so the build-behavior differences don't apply here.

## Behavioral notes

- The **release tarball name is unchanged** (`lecture-python-programming-html-<tag>.tar.gz`). The **checksum/manifest filenames change** from the fixed `html-checksum.txt` / `html-manifest.json` to `lecture-python-programming-html-checksum.txt` / `-manifest.json`, and the manifest gains `name` + `repository` fields — matching the convention the other repos already use.
- Verify with the first `publish*` tag after merge.

References: [publish-gh-pages@v0.8.0](https://github.com/QuantEcon/actions/tree/v0.8.0/publish-gh-pages)
