### PR TITLE
⚙️ Disable spot instances on GPU runners (use on-demand)

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - uses: actions/checkout@v7
       - name: Setup Anaconda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Aligns `lecture-python-programming` with the other GPU repos — `lecture-jax` (QuantEcon/lecture-jax#327) and `lecture-python.myst` (QuantEcon/lecture-python.myst#936) — by forcing on-demand GPU runners: adds `spot=false` to the RunsOn label in `cache.yml` and `ci.yml`.

This repo was the only one of the three `g4dn.2xlarge` GPU repos still relying on RunsOn's default (spot) instead of explicitly forcing on-demand, so spot-interrupted builds were still possible here. This change makes the runner configuration consistent across the GPU repos.

Runner sizing / image / volume are unchanged — this only sets `spot=false`.

Surfaced during the Anaconda 2026.06 audit (see QuantEcon/workspace-lectures#7).
