### PR TITLE
Add French translation sync workflow (sync-translations-fr.yml)

### DIFF
--- a/.github/workflows/sync-translations-fr.yml
+++ b/.github/workflows/sync-translations-fr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.15.0
+      - uses: QuantEcon/action-translation@v0.16.0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fr

--- a/.github/workflows/sync-translations-fr.yml
+++ b/.github/workflows/sync-translations-fr.yml
@@ -1,0 +1,35 @@
+# Sync Translations — French
+# On merged PR, translate changed lectures into the French target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
+name: Sync Translations (French)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0.15.0
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-python-programming.fr
+          target-language: fr
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}


### PR DESCRIPTION
Wires automated French translation sync for the new `QuantEcon/lecture-python-programming.fr` edition — step 3 of the fr rollout tracked in QuantEcon/project-translation#3.

The workflow is a clone of `sync-translations-fa.yml` with three substitutions: `target-repo: QuantEcon/lecture-python-programming.fr`, `target-language: fr`, and `target-language`-appropriate naming. On each merged PR touching `lectures/**/*.md` or `lectures/_toc.yml` it opens a translation PR in the target repo; commenting `\translate-resync` on a merged PR re-triggers it.

## Pin: `@v0.16.0`, unlike its siblings

This PR originally pinned `@v0.15.0`, matching `fa` and `zh-cn`. It now pins [`@v0.16.0`](https://github.com/QuantEcon/action-translation/releases/tag/v0.16.0), released 2026-07-15 (bumped in 07b2b6b), whose default model is **`claude-sonnet-5`** rather than `claude-sonnet-4-6`.

That divergence is deliberate. French is the edition we've looked at on Sonnet 5; `fa` and `zh-cn` haven't been, and silently changing the model for two live editions isn't this PR's business. The estate therefore runs two action versions until that's decided on purpose — tracked in QuantEcon/project-translation#5.

## Merge order

**`QuantEcon/lecture-python-programming.fr#1` (the seed) must merge first.** It adds the 26 bulk-translated lectures (step 2 of the rollout). Merging this before then would fire syncs into a content-less repo.

The first sync after merge also live-verifies that `QUANTECON_SERVICES_PAT` can push to the new `.fr` repo — the one gate that can't be checked ahead of time.

## Two caveats about what this turns on

**French sync will not apply typography.** v0.16.0 ships a deterministic pass for the non-breaking space French needs before `; : ! ?`, but it's wired into the CLI seed path only, not sync — verified: `applyTypography` appears zero times in the action bundle. The seeded corpus is typography-correct; synced sections won't be, so it drifts toward mixed until QuantEcon/action-translation#81 is settled. `scripts/typography/apply.mjs` is the stopgap.

Severity, honestly: the defect is invisible. Both Sonnet 5 and Opus 4.8 already write `Bonjour !` — they just emit an ordinary space where French wants U+00A0, which renders identically and only matters when a line wraps. Synced French will read correctly.

**Sonnet 5 has not been measured against Sonnet 4.6 on this corpus.** The v0.16.0 default change was justified by a general capability claim, not a measurement on MyST lecture translation — tracked in QuantEcon/action-translation#82. Model upgrades are very likely the right direction; we just don't have the evidence yet, and French will be the first edition on Sonnet 5. If 4.6 turns out better, the fix is a constant and a pin, not a re-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
