### PR TITLE
Add French translation sync workflow

### DIFF
--- a/.github/workflows/sync-translations-fr.yml
+++ b/.github/workflows/sync-translations-fr.yml
@@ -1,0 +1,35 @@
+# Sync Translations — French
+# On merged PR, translate changed lectures into the French target repo.
+# Comment \translate-resync on a merged PR to re-trigger sync.
+name: Sync Translations (French)
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'lectures/**/*.md'
+      - 'lectures/_toc.yml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  sync:
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '\translate-resync'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - uses: QuantEcon/action-translation@v0.16.0
+        with:
+          mode: sync
+          target-repo: QuantEcon/lecture-python-programming.fr
+          target-language: fr
+          source-language: en
+          docs-folder: lectures
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.QUANTECON_SERVICES_PAT }}


### PR DESCRIPTION
Adds `sync-translations-fr.yml`, so merged PRs here also translate into the French edition. Without it, `lecture-python-programming.fr` never tracks English — it was seeded and would sit frozen from the next merge onward.

The file is a copy of `sync-translations-zh-cn.yml` with four changes — header comment, workflow name, `target-repo`, `target-language` — plus the action pin. Same triggers, same `\translate-resync` comment escape hatch, same secrets already used by the `fa` and `zh-cn` workflows.

## Pinned to @v0.16.0, unlike its siblings

The `fa` and `zh-cn` sync workflows pin `@v0.15.0`, which defaults to `claude-sonnet-4-6`. This one pins [`@v0.16.0`](https://github.com/QuantEcon/action-translation/releases/tag/v0.16.0), released today, whose default is **`claude-sonnet-5`**.

That divergence is deliberate, not an oversight. French is the edition we've evaluated on Sonnet 5; `fa` and `zh-cn` haven't been, and silently changing the model for two established editions isn't something this PR should do. The trade-off is that the repo temporarily runs two action versions — worth knowing when debugging, and worth revisiting once someone decides to move the other editions.

## Merge order

**`QuantEcon/lecture-python-programming.fr#1` (the seed) should merge first.** It adds the 26 translated lectures. If sync goes live against an empty target, the first merged PR here would try to sync into a repo with no lectures to update.

## What French sync will and won't do

It will translate changed lectures into `.fr` with Sonnet 5 and open PRs there.

It will **not** apply French typography. `action-translation` v0.16.0 ships a deterministic pass for the non-breaking space French requires before `; : ! ?`, but it's wired into the CLI seed path only — not sync. The seeded French corpus is currently typography-correct; synced sections will not be, so the corpus will drift toward mixed typography until that's resolved. Tracked in QuantEcon/action-translation#81, with `scripts/typography/apply.mjs` available as a stopgap.

Worth being precise about the severity: the defect is invisible. Both Sonnet 5 and Opus 4.8 already write `Bonjour !` — they just emit an ordinary space where French wants U+00A0, which renders identically and only matters when a line wraps. Synced French will read correctly; it will be typographically imperfect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
