### PR TITLE
chore: upgrade action-translation to v0.16.1

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.15.0
+      - uses: QuantEcon/action-translation@v0.16.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-fr.yml
+++ b/.github/workflows/sync-translations-fr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.16.0
+      - uses: QuantEcon/action-translation@v0.16.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fr

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.15.0
+      - uses: QuantEcon/action-translation@v0.16.1
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Brings all three sync workflows onto **v0.16.1**: `zh-cn` and `fa` from v0.15.0, `fr` from v0.16.0.

## What this actually changes for zh-cn and fa

These two have been on v0.15.0, so this is **also the Sonnet 4.6 → Sonnet 5 default-model change** that shipped in v0.16.0 and that they never picked up. `fr` has been running Sonnet 5 since it was seeded.

**This was validated before the bump**, not assumed:

- The 26-scenario e2e harness ran v0.16.1 + Sonnet 5 against **both** `zh-cn` and `fa` — 26/26 correct translation PRs in each language, covering section add/delete/reorder, code cells, display math, TOC operations, deep nesting, special characters, and RTL.
- Quality was graded against the December 2025 baseline using the **same judge model** that produced it (`claude-opus-4-5-20251101`):

  | | Dec 2025 (Sonnet 4.5) | v0.16.1 (Sonnet 5) |
  |---|---|---|
  | Avg translation | 9.5/10 | **9.4/10** |
  | Avg diff | 10/10 | **10/10** |
  | Verdicts | 24/24 pass | 25/25 pass |

  A second read with a current-generation judge (Opus 4.8) scored translation **9.6/10**.

Worth stating plainly: Sonnet 4.6 — what zh-cn and fa run *today* — was never measured. This upgrade moves them from an unmeasured model to one benchmarked against the last known-good baseline.

## Correctness fixes that come with it

- **API pagination** — PRs touching >30 files were silently synced only in part.
- **Truncation detection** — a translation cut off at `max_tokens` was committed as if complete; it now fails loudly. Most likely to be felt on long lectures.
- **Empty-response guard** — a refusal/empty response threw a bare `TypeError`.
- **French typography** — footnote/link-reference definitions were being corrupted (`[^id]:` → `[^id] :`), which broke the definition and every reference to it.

Detail: QuantEcon/action-translation#83 · [v0.16.1 release notes](https://github.com/QuantEcon/action-translation/releases/tag/v0.16.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)