### PR TITLE
Retire the last references to the retired lecture-python repo

### DIFF
--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -77,7 +77,7 @@ countries and assign it to `realwage`.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url1 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python/master/source/_static/lecture_specific/pandas_panel/realwage.csv'
+url1 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/realwage.csv'
 ```
 
 ```{code-cell} ipython3
@@ -197,7 +197,7 @@ function.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url2 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python/master/source/_static/lecture_specific/pandas_panel/countries.csv'
+url2 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/countries.csv'
 ```
 
 ```{code-cell} ipython3
@@ -506,7 +506,7 @@ in Europe by age and sex from [Eurostat](https://ec.europa.eu/eurostat/data/data
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url3 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python/master/source/_static/lecture_specific/pandas_panel/employ.csv'
+url3 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/employ.csv'
 ```
 
 Reading in the CSV file returns a panel dataset in long format. Use `.pivot_table()` to construct

--- a/lectures/pandas_panel.md
+++ b/lectures/pandas_panel.md
@@ -77,7 +77,7 @@ countries and assign it to `realwage`.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url1 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/realwage.csv'
+url1 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas_panel/realwage.csv'
 ```
 
 ```{code-cell} ipython3
@@ -197,7 +197,7 @@ function.
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url2 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/countries.csv'
+url2 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas_panel/countries.csv'
 ```
 
 ```{code-cell} ipython3
@@ -506,7 +506,7 @@ in Europe by age and sex from [Eurostat](https://ec.europa.eu/eurostat/data/data
 The dataset can be accessed with the following link:
 
 ```{code-cell} ipython3
-url3 = 'https://github.com/QuantEcon/lecture-python-programming/raw/refs/heads/main/lectures/_static/lecture_specific/pandas_panel/employ.csv'
+url3 = 'https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas_panel/employ.csv'
 ```
 
 Reading in the CSV file returns a panel dataset in long format. Use `.pivot_table()` to construct


### PR DESCRIPTION
After this, **nothing in this repo references `QuantEcon/lecture-python`** — the repo it was migrated from, last touched **2022-01-21**. Mirrors QuantEcon/lecture-python.myst#968.

## What it changes

`pandas_panel` read all three of `realwage.csv`, `countries.csv` and `employ.csv` from the retired repo, even though this repo **already has its own committed copies of all three** under `_static/lecture_specific/pandas_panel/`. Three lines; now it reads its own.

## Verification

| File | own-repo copy | legacy repo | new URL serves |
| --- | --- | --- | --- |
| `realwage.csv` | identical | identical | identical |
| `countries.csv` | identical | identical | identical |
| `employ.csv` | identical | identical | identical |

sha256-compared before repointing, so lecture output cannot change.

## Interim by design — and it costs P2 nothing

QuantEcon/workspace-lectures#14 says to skip `pandas_panel` because pilot P2 (QuantEcon/meta#338) migrates this trio to `QuantEcon/data-lectures`, making an interim repoint churn. P2 rewrites these three lines whether they say "legacy" or "own-repo" today, so this adds nothing to it — and P2 turns out to be further off than scoped (an audit today found the trio is consumed by 6 source repos / 17 references, not the 2 / 5 planned). Meanwhile the dependency on an unmaintained repo is the same shape as the bug QuantEcon/meta#337 risk 1 just cost us.

Part of QuantEcon/meta#337
See QuantEcon/meta#336
