### PR TITLE
chore: track action-translation @v0 in the fr sync workflow

### DIFF
--- a/.github/workflows/sync-translations-fr.yml
+++ b/.github/workflows/sync-translations-fr.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.16.1
+      - uses: QuantEcon/action-translation@v0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fr


### PR DESCRIPTION
The fr target repo's review and rebase workflows adopted the floating `@v0` pin in QuantEcon/lecture-python-programming.fr#10. This brings the source-side `sync-translations-fr.yml` in line, so fr syncs run v0.17.0 — whose sync write path preserves French non-breaking spaces (QuantEcon/action-translation#97) and dedupes review comments (QuantEcon/action-translation#96) — and pick up future v0.x releases without manual bumps.

Not touched here: `sync-translations-zh-cn.yml` and `sync-translations-fa.yml` remain pinned at `@v0.16.1`. Happy to follow up with the same change for those if the floating pin is the fleet convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)