### PR TITLE
Track @v0 in the fa and zh-cn sync workflows

### DIFF
--- a/.github/workflows/sync-translations-fa.yml
+++ b/.github/workflows/sync-translations-fa.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.16.1
+      - uses: QuantEcon/action-translation@v0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.fa

--- a/.github/workflows/sync-translations-zh-cn.yml
+++ b/.github/workflows/sync-translations-zh-cn.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: QuantEcon/action-translation@v0.16.1
+      - uses: QuantEcon/action-translation@v0
         with:
           mode: sync
           target-repo: QuantEcon/lecture-python-programming.zh-cn


### PR DESCRIPTION
Completes the pin migration this repo started for French in #581.

**Translation happens in the source repo's sync workflow**, not in the target — so these two pins govern which engine version actually translates `fa` and `zh-cn` content. They were still on `@v0.16.1`, two releases behind. That asymmetry is exactly what let French syncs keep stripping non-breaking spaces for four days after the target-side migration in [.fr#10](https://github.com/QuantEcon/lecture-python-programming.fr/pull/10) had supposedly fixed it; #581 closed that gap for French and this closes it for the other two.

## Why floating `@v0`

The policy settled in QuantEcon/project-translation#9: it is the action's own documented convention (19 occurrences in its docs against a single exact pin), its floating tags are well maintained, and development tempo is fast enough that hand-bumping reliably lags the releases worth having. The residual "0.x may break" risk is mitigated not by the pin but by **sync output landing as a PR a human reviews before merge**.

## What this completes

With these two, all **nine** translation workflow pins across the programming trio track `@v0`:

| Repo | Workflow | Mode | Pin after this PR |
| --- | --- | --- | --- |
| lecture-python-programming | sync-translations-fr.yml | sync | ✅ `@v0` (#581) |
| lecture-python-programming | sync-translations-fa.yml | sync | ✅ `@v0` (this PR) |
| lecture-python-programming | sync-translations-zh-cn.yml | sync | ✅ `@v0` (this PR) |
| .fr | review + rebase | review/rebase | ✅ `@v0` |
| .fa | review + rebase | review/rebase | ✅ `@v0` ([fa#137](https://github.com/QuantEcon/lecture-python-programming.fa/pull/137)) |
| .zh-cn | review + rebase | review/rebase | ✅ `@v0` ([zh-cn#73](https://github.com/QuantEcon/lecture-python-programming.zh-cn/pull/73)) |

The practical effect is that future engine releases reach production **on merge**, rather than needing a rollout PR round each time — which matters because a queue of silent-corruption fixes is being worked in `action-translation` right now ([#120](https://github.com/QuantEcon/action-translation/issues/120)).

Part of Stage 1 of the translation program work plan. See QuantEcon/project-translation#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)