### PR TITLE
FIX: update GitHub pull requests doc link to final destination

### DIFF
--- a/lectures/workspace.md
+++ b/lectures/workspace.md
@@ -361,7 +361,7 @@ As the 2nd task,
 1. Look into 'forking' GitHub repositories (forking means making your own copy of a GitHub repository, stored on GitHub).
 1. Fork [QuantEcon.py](https://github.com/QuantEcon/QuantEcon.py).
 1. Clone your fork to some local directory, make edits, commit them, and push them back up to your forked GitHub repo.
-1. If you made a valuable improvement, send us a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)!
+1. If you made a valuable improvement, send us a [pull request](https://docs.github.com/en/pull-requests/reference/pull-requests)!
 
 For reading on these and other topics, try
 


### PR DESCRIPTION
Fixes the one genuine finding in #587.

The GitHub docs URL for "About pull requests" in `lectures/workspace.md` now 301-redirects, so this points it directly at the destination:

| | URL |
|---|---|
| before | `https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests` |
| after | `https://docs.github.com/en/pull-requests/reference/pull-requests` |

This matches the AI suggestion in the report, and I verified the redirect chain resolves `301` to that exact target with a `200`.

## About the other two findings in #587

The two FRED links reported as broken are **false positives** and need no change here. Both return `200` in well under a second from a normal network; the `0 (Timeout)` status is FRED throttling GitHub Actions runner IPs. They are already whitelisted for Sphinx in `lectures/_config.yml` under `linkcheck_ignore`, but the link checker scans built HTML and never sees that configuration.

That is the root cause of the eight older duplicate issues (#555, #556, #559, #564, #565, #567, #571, #583), which I am closing in favour of #587. The fix belongs in the action rather than in this repo, and is tracked upstream in QuantEcon/action-link-checker#2, which requests an `ignore-patterns` input plus issue deduplication.

## Heads-up for the next release

The report only flags `pandas.html`, but `lectures/polars.md` carries the identical FRED link. The checker runs against the latest release tarball, which predates the Polars lecture, so expect these to double to four false positives after the next release until the upstream ignore list lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
