### PR TITLE
Harden linkcheck.yml, declare known false positives, and pin the action to v1

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,6 +9,7 @@ jobs:
     name: QuantEcon AI link checking
     runs-on: "ubuntu-latest"
     permissions:
+      contents: read  # read latest release assets via gh api
       issues: write   # required for QuantEcon link-checker
     steps:
       # Download the latest release HTML archive (permanent, not subject to artifact expiry)
@@ -17,19 +18,39 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           ASSET_URL=$(gh api repos/${{ github.repository }}/releases/latest \
-            --jq '.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url')
-          echo "asset-url=$ASSET_URL" >> $GITHUB_OUTPUT
+            --jq '[.assets[] | select(.name | endswith(".tar.gz")) | .browser_download_url] | first // ""')
+          if [ -z "$ASSET_URL" ]; then
+            echo "::error::No .tar.gz asset found on the latest release"
+            exit 1
+          fi
+          echo "asset-url=$ASSET_URL" >> "$GITHUB_OUTPUT"
       - name: Download and extract release HTML
         run: |
+          set -euo pipefail
           mkdir -p _site
-          curl -sL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
+          curl -fsSL "${{ steps.release.outputs.asset-url }}" | tar -xz -C _site
       - name: AI-Powered Link Checker
-        uses: QuantEcon/action-link-checker@main
+        uses: QuantEcon/action-link-checker@v1
         with:
           html-path: '_site'
           fail-on-broken: 'false'
           silent-codes: '403,503'
           ai-suggestions: 'true'
           create-issue: 'true'
-
+          # Known false positives, kept in step with the linkcheck_ignore list in
+          # lectures/_config.yml. Sphinx's built-in checker reads that list; this
+          # checker scans the built HTML and never sees it, so the exemptions have
+          # to be stated in both places. Same regex syntax, so entries move across
+          # unchanged -- update both when adding one.
+          ignore-patterns: |
+            https://github.com/matplotlib/matplotlib/blob/v3.6.2/lib/matplotlib/axes/_axes.py#L1417-L1669
+            https://ieeexplore.ieee.org/document/8757088
+            https://www.sciencedirect.com/science/article/pii/S1477388021000177
+            https://keras.io/
+            https://data.oecd.org/
+            https://www.reddit.com/
+            https://openai.com
+            https://chatgpt.com/
+            https://fred.stlouisfed.org/.*

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -43,7 +43,10 @@ jobs:
           # lectures/_config.yml. Sphinx's built-in checker reads that list; this
           # checker scans the built HTML and never sees it, so the exemptions have
           # to be stated in both places. Same regex syntax, so entries move across
-          # unchanged -- update both when adding one.
+          # directly -- but the matching differs: Sphinx anchors a pattern at the
+          # start of the URL, this checker matches anywhere in it. A pattern
+          # copied here can therefore match more than it does there, never less.
+          # Update both when adding one, and anchor deliberately if it matters.
           ignore-patterns: |
             https://github.com/matplotlib/matplotlib/blob/v3.6.2/lib/matplotlib/axes/_axes.py#L1417-L1669
             https://ieeexplore.ieee.org/document/8757088


### PR DESCRIPTION
Closes #566, and wires up the `ignore-patterns` input that shipped in action-link-checker v1.1.0.

## The hardening from #566

Applied as filed, matching what already landed in QuantEcon/lecture-python-intro#783:

| Change | Why |
|---|---|
| `contents: read` added to `permissions` | The block granted only `issues: write`, and `permissions:` resets every unlisted scope to `none` — so `gh api .../releases/latest` was running with `contents: none` |
| `set -euo pipefail` and single-asset selection | The old jq emitted one line per matching asset, with nothing to stop an empty or multi-line result flowing into `curl` |
| `curl -fsSL` | Without `-f`, an HTTP error page is piped into `tar` and surfaces as a cryptic extraction error rather than a download failure |

Verified the new selector against this repo's current latest release — it returns the `publish-2026aug03` tarball, the same URL the old form produced.

## Known false positives

This repo has kept a `linkcheck_ignore` list in `lectures/_config.yml` for years. Sphinx's built-in checker honours it; this checker scans built HTML and never sees the Sphinx config, so the same links were re-reported every week. The regex syntax is identical, so the nine entries move across unchanged.

FRED is the one that mattered. It throttles datacenter IP ranges, so it times out from a runner while returning `200` in under half a second from a normal network — and `https://fred.stlouisfed.org/.*` has been in `_config.yml` since April. Seventeen duplicate issues were filed for those two links between April and July before the batch was closed this morning.

## Verification against the real site

Rather than assume the patterns match, I downloaded the current release tarball and ran the shipped v1.1.0 `compile_ignore_patterns` / `is_ignored` against the actual built HTML:

- **33 HTML files, 955 external anchors**
- **7 anchors now skipped, 6 distinct URLs** — the three FRED anchors (`fred.stlouisfed.org/` twice, `/series/UNRATE` once), plus `openai.com/`, `reddit.com/`, `keras.io/` and the pinned matplotlib source line
- **No FRED link remains checked**, on either `pandas.html` or `polars.html`
- The other 948 anchors are unaffected

Note that `openai.com/` matched the bare `https://openai.com` entry — `re.search` semantics, so the trailing slash is not a problem. Four entries in the list match nothing in the current build; they are harmless and kept so the two lists stay identical.

Correcting an estimate I gave earlier: the next scheduled run would have reported **three** FRED URLs, not six. The higher number came from counting mentions in the Markdown source, which includes prose references that never become anchors.

## Pinning to `@v1`

#566 recorded a deliberate decision to stay on `@main` because this is a first-party action, and that reasoning still holds. What changed is that v1.1.0 shipped a **default-on behaviour change** — with `create-issue: true`, a recurring finding now refreshes one open issue instead of opening a new one each week — and it reached this repo the instant it merged, with no gate.

`@v1` is a moving tag, so patches and features still arrive automatically. It only means a change of that kind becomes something adopted rather than received.

**This should not stay a one-repo decision.** Three other repos use this action — `lecture-python-intro`, `lecture-python-advanced.myst` and `continuous_time_mcs` — and a series split across two pinning schemes is worse than either scheme. They also each need their own `ignore-patterns` before their FRED reports stop. Happy to open the matching PRs.

## After this merges

The next scheduled run is 23:00 UTC. It should be the first clean one in months. If anything is still reported, `ignored-count` in the job log shows exactly what was skipped.
