### PR TITLE
CI: pin jupyter-book<2 in the execution test workflows

### DIFF
--- a/.github/workflows/execution-linux.yml
+++ b/.github/workflows/execution-linux.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # UTC 15:00 is early morning in Australia
     - cron:  '0 15 * * *'
+  workflow_dispatch:
 jobs:
   execution-tests-linux:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -23,7 +24,10 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install anaconda
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
+          # jupyter-book pinned <2: the 2.x line drops the jb CLI (see #569);
+          # this repo stays on jupyter-book 1.x until a JB2-compatible theme
+          # exists (mirrors the <2.0 pin in environment.yml)
+          pip install "jupyter-book<2" sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |

--- a/.github/workflows/execution-osx.yml
+++ b/.github/workflows/execution-osx.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # UTC 16:00 is early morning in Australia
     - cron:  '0 15 * * 1'
+  workflow_dispatch:
 jobs:
   execution-tests-osx:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -23,7 +24,10 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install anaconda
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
+          # jupyter-book pinned <2: the 2.x line drops the jb CLI (see #569);
+          # this repo stays on jupyter-book 1.x until a JB2-compatible theme
+          # exists (mirrors the <2.0 pin in environment.yml)
+          pip install "jupyter-book<2" sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |

--- a/.github/workflows/execution-win.yml
+++ b/.github/workflows/execution-win.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # UTC 17:00 is early morning in Australia
     - cron:  '0 15 * * 4'
+  workflow_dispatch:
 jobs:
   execution-tests-win:
     name: Execution Tests (${{ matrix.python-version }}, ${{ matrix.os }})
@@ -27,8 +28,10 @@ jobs:
           conda install anaconda
           conda install -c numba numba
           conda install -c numba llvmlite
-          pip install jupyter-book
-          pip install jupyter-book sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
+          # jupyter-book pinned <2: the 2.x line drops the jb CLI (see #569);
+          # this repo stays on jupyter-book 1.x until a JB2-compatible theme
+          # exists (mirrors the <2.0 pin in environment.yml)
+          pip install "jupyter-book<2" sphinx-multitoc-numbering quantecon-book-theme sphinxext-rediraffe sphinx-tojupyter sphinx-exercise sphinx-togglebutton
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Closes #569.

Every scheduled run of the three "Execution Tests [Latest Anaconda]" workflows has failed with `jb: command not found` since jupyter-book 2.x became the default pip target (~10 weeks) — the 2.x line drops the `jb` CLI, so the unpinned `pip install jupyter-book` silently swapped the toolchain out from under the build step.

**Decision context:** the repo stays firmly on `jupyter-book<2` until a JB2-compatible theme exists (the mystmd migration is tracked separately in #593 / PR #363). That keeps these workflows relevant for their stated purpose — testing the lectures against the **latest Anaconda** — so the fix pins only jupyter-book rather than switching to `environment-file: environment.yml`, which would have made them near-duplicates of `cache.yml`.

## Changes (all three `execution-*.yml`)

- `pip install "jupyter-book<2" ...`, mirroring the `<2.0` pin in `environment.yml`, with a comment explaining the pin so it isn't "cleaned up" later.
- `execution-win.yml`: dropped the duplicate bare `pip install jupyter-book` that preceded the full install line.
- Added `workflow_dispatch:` — the workflows were schedule-only, which is why this breakage could only be observed on the daily/weekly cadence. With the trigger, the fix (and any future change) can be validated on demand.

## Verification

A `workflow_dispatch` run of the linux workflow against this branch is the real test — a green `cache.yml` proves nothing here since it installs from the pinned `environment.yml`. Note that after ~10 weeks without signal, the first run may surface genuine execution drift (new package versions from latest Anaconda) beyond the install fix; those would be real findings, not regressions from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
