### PR TITLE
FIX: point the Polars benchmarks link at its final destination

### DIFF
--- a/lectures/polars.md
+++ b/lectures/polars.md
@@ -51,7 +51,7 @@ Polars is designed with performance and memory efficiency in mind, leveraging:
 
 * **Memory**: pandas typically needs 5--10x your dataset size in RAM; Polars needs only 2--4x
 * **Speed**: Polars is 10--100x faster for many common operations
-* **See**: [Polars TPC-H benchmarks](https://www.pola.rs/benchmarks/) for up-to-date performance comparisons
+* **See**: [Polars TPC-H benchmarks](https://pola.rs/benchmarks/) for up-to-date performance comparisons
 ```
 
 Throughout the lecture, we will assume that the following imports have taken place


### PR DESCRIPTION
One of the two redirects in the 2026-08-03 link-check report (#597): `www.pola.rs/benchmarks/` → `pola.rs/benchmarks/` in `polars.md` (verified 200, no redirect).

The other flagged redirect — `workspace.html`'s GitHub PR-docs link — is **already fixed on `main`** by #590; the report sees the old URL because it checks the published site, which hasn't been republished since. It will clear on the next publish, which makes #597 a live example of the drift described in #591.

No closing keyword on purpose: #597 should stay open (the action refreshes its body in place) until a publish clears the workspace redirect, then be closed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)