### PR TITLE
Run GPU builds on-demand: add spot=false to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs['page-url'] }}


### PR DESCRIPTION
`cache.yml` and `ci.yml` here already pin `spot=false`; `publish.yml` was the one GPU workflow still on RunsOn's spot default, exposed to the mid-run reclamation failure diagnosed in QuantEcon/meta#330.

This adds `spot=false` to its `runs-on` string, completing this repo's part of the rollout tracked in QuantEcon/meta#330; the audit that found it is QuantEcon/meta#347 (item 1, as corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)