### PR TITLE
FIX: seven source-side defects in python_by_example, functions, numpy and pandas

### DIFF
--- a/lectures/functions.md
+++ b/lectures/functions.md
@@ -447,7 +447,7 @@ def x(t):
         return 2 * x(t-1)
 ```
 
-What happens here is that each successive call uses it's own *frame* in the *stack*
+What happens here is that each successive call uses its own *frame* in the *stack*
 
 * a frame is where the local variables of a given function call are held
 * stack is memory used to process function calls

--- a/lectures/functions.md
+++ b/lectures/functions.md
@@ -451,7 +451,7 @@ What happens here is that each successive call uses it's own *frame* in the *sta
 
 * a frame is where the local variables of a given function call are held
 * stack is memory used to process function calls
-  * a First In Last Out (FILO) queue
+  * a last-in, first-out (LIFO) data structure
 
 This example is somewhat contrived, since the first (iterative) solution would usually be preferred to the recursive solution.
 

--- a/lectures/numpy.md
+++ b/lectures/numpy.md
@@ -215,7 +215,7 @@ z
 See also `np.asarray`, which performs a similar function, but does not make
 a distinct copy of data already in a NumPy array.
 
-To read in the array data from a text file containing numeric data use `np.loadtxt` ---see [the documentation](https://numpy.org/doc/stable/reference/routines.io.html) for details.
+To read in the array data from a text file containing numeric data use `np.loadtxt` --- see [the documentation](https://numpy.org/doc/stable/reference/routines.io.html) for details.
 
 
 
@@ -1271,7 +1271,7 @@ you will understand.
 
 There is a problem here, however.
 
-Suppose that `q` is altered after an instance of `discreteRV` is
+Suppose that `q` is altered after an instance of `DiscreteRV` is
 created, for example by
 
 ```{code-cell} python3
@@ -1406,11 +1406,11 @@ F.plot(ax)
 :label: np_ex4
 ```
 
-Recall that [broadcasting](broadcasting) in Numpy can help us conduct element-wise operations on arrays with different number of dimensions without using `for` loops.
+Recall that [broadcasting](broadcasting) in NumPy can help us conduct element-wise operations on arrays with different number of dimensions without using `for` loops.
 
 In this exercise, try to use `for` loops to replicate the result of the following broadcasting operations.
 
-**Part1**: Try to replicate this simple example using `for` loops and compare your results with the broadcasting operation below.
+**Part 1**: Try to replicate this simple example using `for` loops and compare your results with the broadcasting operation below.
 
 ```{code-cell} python3
 
@@ -1429,7 +1429,7 @@ tags: [hide-output]
 print(A)
 ```
 
-**Part2**: Move on to replicate the result of the following broadcasting operation. Meanwhile, compare the speeds of broadcasting and the `for` loop you implement.
+**Part 2**: Move on to replicate the result of the following broadcasting operation. Meanwhile, compare the speeds of broadcasting and the `for` loop you implement.
 
 For this part of the exercise you can use the `tic`/`toc` functions from the `quantecon` library to time the execution. 
 

--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -380,7 +380,7 @@ df.apply(update_row, axis=1)
 
 ```{code-cell} ipython3
 # Round all decimal numbers to 2 decimal places
-df.map(lambda x : round(x,2) if type(x)!=str else x)
+df.map(lambda x : round(x,2) if not isinstance(x, str) else x)
 ```
 
 **Application: Missing Value Imputation**
@@ -403,8 +403,8 @@ We can use the `.map()` method again to replace all missing values with 0
 ```{code-cell} ipython3
 # replace all NaN values by 0
 def replace_nan(x):
-    if type(x)!=str:
-        return  0 if np.isnan(x) else x
+    if not isinstance(x, str):
+        return  0 if pd.isna(x) else x
     else:
         return x
 
@@ -536,7 +536,7 @@ In the second case, you can either
 * switch to another machine
 * solve your proxy problem by reading [the documentation](https://requests.readthedocs.io/en/latest/)
 
-Assuming that all is working, you can now proceed to use the `source` object returned by the call `requests.get('https://research.stlouisfed.org/fred2/series/UNRATE/downloaddata/UNRATE.csv')`
+Assuming that all is working, you can now proceed to build the `source` object from the data returned by the call `requests.get(url)`
 
 ```{code-cell} ipython3
 url = 'https://fred.stlouisfed.org/graph/fredgraph.csv?bgcolor=%23e1e9f0&chart_type=line&drp=0&fo=open%20sans&graph_bgcolor=%23ffffff&height=450&mode=fred&recession_bars=on&txtcolor=%23444444&ts=12&tts=12&width=1318&nt=0&thu=0&trc=0&show_legend=yes&show_axis_titles=yes&show_tooltip=yes&id=UNRATE&scale=left&cosd=1948-01-01&coed=2024-06-01&line_color=%234572a7&link_values=false&line_style=solid&mark_type=none&mw=3&lw=2&ost=-99999&oet=99999&mma=0&fml=a&fq=Monthly&fam=avg&fgst=lin&fgsnd=2020-02-01&line_index=1&transformation=lin&vintage_date=2024-07-29&revision_date=2024-07-29&nd=1948-01-01'

--- a/lectures/python_by_example.md
+++ b/lectures/python_by_example.md
@@ -380,9 +380,9 @@ plt.plot(ϵ_values)
 plt.show()
 ```
 
-A while loop will keep executing the code block delimited by indentation until the condition (```i < ts_length```) is satisfied.
+A while loop will keep executing the code block delimited by indentation until the condition (`i < ts_length`) is satisfied.
 
-In this case, the program will keep adding values to the list ```ϵ_values``` until ```i``` equals ```ts_length```:
+In this case, the program will keep adding values to the list `ϵ_values` until `i` equals `ts_length`:
 
 ```{code-cell} python3
 i == ts_length #the ending condition for the while loop

--- a/lectures/python_by_example.md
+++ b/lectures/python_by_example.md
@@ -380,7 +380,7 @@ plt.plot(ϵ_values)
 plt.show()
 ```
 
-A while loop will keep executing the code block delimited by indentation until the condition (`i < ts_length`) is satisfied.
+A while loop will keep executing the code block delimited by indentation as long as the condition (`i < ts_length`) is satisfied.
 
 In this case, the program will keep adding values to the list `ϵ_values` until `i` equals `ts_length`:
 


### PR DESCRIPTION
Addresses #602. Each of the eight reports was validated against the source before anything was changed. Seven are actioned here and one is a false positive, left alone with the reasoning below. Two of the seven (items 1 and 2) turned out to be style and readability improvements rather than the defects they were reported as — noted individually below.

## What changed

| # | File | Fix | Verdict |
|---|---|---|---|
| 1 | `python_by_example.md` | Four inline spans written with triple backticks now use single backticks | Cosmetic — see note |
| 2 | `functions.md` | "a First In Last Out (FILO) queue" → "a last-in, first-out (LIFO) data structure" | Wording — see note |
| 3 | `numpy.md` | Space added after the `---` marker at line 218 | Confirmed, wording of the report inverted |
| 4 | `numpy.md` | `Numpy` → `NumPy`; `**Part1**` → `**Part 1**`; **and `**Part2**` → `**Part 2**`** | Confirmed, plus one the report missed |
| 5 | `numpy.md` | Prose `discreteRV` → `DiscreteRV` | Confirmed |
| 6 | `pandas.md` | **No change** — the query is correct as written | **False positive** |
| 7 | `pandas.md` | Dead `research.stlouisfed.org` URL removed from the prose | Confirmed, 301 → 404 |
| 8 | `pandas.md` | `type(x) != str` → `not isinstance(x, str)`; `np.isnan` → `pd.isna` | Confirmed |

## Item 6 is a false positive — the query is correct

The report claims that `df.query("cc + cg >= 80 & POP <= 20000")` is not equivalent to the parenthesised boolean-indexing example above it, because `&` binds tighter than the comparisons. That is true of plain Python, but it is not true inside `DataFrame.query`.

With the default `parser='pandas'`, pandas runs a token-level preparse (`_replace_booleans` in `pandas/core/computation/expr.py`) that rewrites the `&` token to `and` **before** the string reaches `ast.parse`. Its docstring says so explicitly: *"Replace `&` with `and` and `|` with `or` so that bitwise precedence is changed to boolean precedence."* The expression therefore parses with boolean precedence and needs no parentheses.

Verified empirically on the lecture's own dataset — both forms return the same two rows (Malawi, Uruguay) and `.equals()` is `True`. Instrumenting the live `query()` call shows the expression arriving at the parser as `cc +cg >=80 and POP <=20000`, i.e. already rewritten. The surrounding prose ("the above is equivalent to") is accurate, so nothing here needs changing.

## Item 1 is a real inconsistency but not a rendering bug

The report's stated reason — "triple backticks are fence syntax" — does not hold for a span that opens and closes mid-paragraph. Per CommonMark a fence must begin at the start of a line, and a code span may use any number of backticks as long as the runs match, so these render as `<code>` today under both myst-parser 3.0.1 and mystmd 1.10.1. The rendered HTML before and after this change is byte-identical.

The change is still worth making: the file has 60 single-backtick spans against these 4, and translated editions copy the source verbatim. Treat it as source hygiene, not a bug fix.

## Item 2 is a readability change, not an error

The report calls "a First In Last Out (FILO) queue" wrong on the grounds that "the standard term is Last In, First Out (LIFO)". The two are equivalent: first-in-last-out and last-in-first-out describe the same access discipline from opposite ends, so the original sentence was not incorrect. Nor is "queue" a category error — Python's stdlib ships `queue.LifoQueue`, documented as "retrieves most recently added entries first", and `asyncio.LifoQueue` alongside it.

The change is still worth making, but on readability grounds rather than correctness: LIFO is the term students meet in CS curricula and in Python's own docs, and FILO is a real but uncommon synonym. "data structure" over "queue" avoids a beginner reading "queue" in its ordinary FIFO sense. Happy to drop this one if you'd rather leave the original wording alone.

## Item 3's wording is inverted, but there is a real defect at that line

The report says "no space before the em-dash marker". There *is* a space before it; the missing one is after. A survey of all 86 mid-sentence `---` uses across `lectures/` gives 79% space-on-both-sides, 16% closed up on both sides, and exactly one hybrid — this line. It is also the only asymmetric case in `numpy.md`, whose other two instances (lines 133 and 448) use the spaced form. Fixed by adding the missing space.

## Item 4 was incomplete as reported

The report lists `**Part1**` at line 1413. The same exercise has `**Part2**` at line 1432, whose matching solution heading at line 1502 already reads `**Part 2 Solution**`. Fixing only the reported line would have left the pair inconsistent, so both are fixed.

## Verification

The two edited code cells were replayed against `test_pwt.csv` in the lecture's exact sequence, comparing the current and proposed versions cell by cell:

| Cell | repr identical | `.equals()` | dtypes identical |
|---|---|---|---|
| `df.map(round…)` | yes | yes | yes |
| `df.map(replace_nan)` | yes | yes | yes |
| downstream `fillna` | yes | yes | yes |

So no rendered notebook output moves and no cached execution is invalidated by the behaviour change. The breakage the report describes does reproduce: `type(x) != str` sends `str` subclasses and `np.str_` into `round()`, and `np.isnan` raises `TypeError` on `None`, `pd.NA`, `pd.NaT` and arbitrary objects where `pd.isna` returns cleanly.

All four files were also parsed before and after with the project's myst-parser 3.0.1 and the repo's extension set. Token counts and structure are unchanged in every file; only the intended inline/fence tokens differ.

The dead FRED URL was re-checked live: `research.stlouisfed.org/fred2/series/UNRATE/downloaddata/UNRATE.csv` returns 301 to `fred.stlouisfed.org/data/UNRATE.csv`, which returns 404. The `fredgraph.csv` URL used by the code cells returns 200. Rather than inline that ~700-character query string into prose as a third copy, the sentence now names `requests.get(url)`, matching the cell immediately below it — so prose and code stay in sync whenever the URL is refreshed.

## Folded in after review (bed9f09)

Two pre-existing prose defects on lines this PR already touches. Both were originally listed below as out-of-scope candidates, and both were independently raised in Copilot's review:

- `python_by_example.md:383` — the sentence said a while loop runs "until the condition is satisfied", which is backwards; it runs *while* the condition holds. It now reads "as long as the condition (`i < ts_length`) is satisfied". This was contradicting the very next sentence at line 385, which already described the behaviour correctly.
- `functions.md:450` — "each successive call uses **it's** own *frame*" → "its". The other four `it's` in that file (lines 96, 98, 190, 415) are correct contractions of "it is" and were left alone.

## Not included — flagged for a separate decision

These came out of a repo-wide sweep for the same defect classes. They are outside the scope of #602, so I have left them alone:

- `workspace.md:273` and `:277` — the same triple-backtick inline spans (```` ```Python: Select Interpreter``` ````, ```` ```Python: Create Environment``` ````). These are the only other instances repo-wide.
- `sympy.md:643` — "Sympy" against 21 correct "SymPy" spellings in the same file.
- `sympy.md` 357, 359, 361, 428, 453 — prose says `Stats` module; the import is lowercase `sympy.stats`. Lower confidence, since the linked SymPy docs page is itself titled "Stats".

Happy to fold any of these in too if you'd rather not open a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
