### PR TITLE
Add a permissions block to ci.yml so the default token can drop to read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on: [pull_request]
 jobs:
   preview:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     permissions:
       contents: read
+      actions: read         # dawidd6/action-download-artifact reads the cache.yml build artifact
       pull-requests: write
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Preparation for QuantEcon/meta#347 item 4 (default workflow token permissions → `read`). `ci.yml`'s Netlify preview step is the one workflow here that relies on the repo-level `write` default; this gives it the same job-level block `lecture-jax/ci.yml` already carries (`contents: read` + `pull-requests: write`). The publish, linkcheck and sync workflows already carry explicit blocks, and `cache.yml`/`execution-*.yml` write nothing with `GITHUB_TOKEN`.

Once a job carries a `permissions:` block, unlisted scopes drop to `none` regardless of the repo default — so this merges safely before or after the settings flip, and it is what makes the flip safe to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)