### PR TITLE
Read test_pwt.csv from data-lectures (Track D)

### DIFF
--- a/lectures/pandas.md
+++ b/lectures/pandas.md
@@ -153,7 +153,7 @@ In essence, a `DataFrame` in pandas is analogous to a (highly optimized) Excel s
 
 Thus, it is a powerful tool for representing and analyzing data that are naturally organized into rows and columns, often with descriptive indexes for individual rows and individual columns.
 
-Let's look at an example that reads data from the CSV file `pandas/data/test_pwt.csv`, which is taken from the [Penn World Tables](https://www.rug.nl/ggdc/productivity/pwt/pwt-releases/pwt-7.0).
+Let's look at an example that reads data from the CSV file `test_pwt.csv`, which is taken from the [Penn World Tables](https://www.rug.nl/ggdc/productivity/pwt/pwt-releases/pwt-7.0).
 
 The dataset contains the following indicators 
 
@@ -169,7 +169,7 @@ The dataset contains the following indicators
 We'll read this in from a URL using the `pandas` function `read_csv`.
 
 ```{code-cell} ipython3
-df = pd.read_csv('https://raw.githubusercontent.com/QuantEcon/lecture-python-programming/main/lectures/_static/lecture_specific/pandas/data/test_pwt.csv')
+df = pd.read_csv('https://github.com/QuantEcon/data-lectures/raw/main/lectures/test_pwt.csv')
 type(df)
 ```
 

--- a/lectures/polars.md
+++ b/lectures/polars.md
@@ -158,9 +158,7 @@ As in {doc}`pandas`, let's work with data from the [Penn World Tables](https://w
 We read this in using `pl.read_csv`
 
 ```{code-cell} ipython3
-url = ('https://raw.githubusercontent.com/QuantEcon/'
-       'lecture-python-programming/main/lectures/_static/'
-       'lecture_specific/pandas/data/test_pwt.csv')
+url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/test_pwt.csv'
 df = pl.read_csv(url)
 df
 ```
@@ -344,9 +342,7 @@ Instead of executing each operation immediately, lazy mode collects the full que
 
 ```{code-cell} ipython3
 # Reload the dataset
-url = ('https://raw.githubusercontent.com/QuantEcon/'
-       'lecture-python-programming/main/lectures/_static/'
-       'lecture_specific/pandas/data/test_pwt.csv')
+url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/test_pwt.csv'
 df_full = pl.read_csv(url)
 ```
 
@@ -422,9 +418,7 @@ import pandas as pd
 import time
 
 # Small dataset -- Penn World Tables (~8 rows)
-url = ('https://raw.githubusercontent.com/QuantEcon/'
-       'lecture-python-programming/main/lectures/_static/'
-       'lecture_specific/pandas/data/test_pwt.csv')
+url = 'https://github.com/QuantEcon/data-lectures/raw/main/lectures/test_pwt.csv'
 small_pd = pd.read_csv(url)
 small_pl = pl.read_csv(url)
 ```


### PR DESCRIPTION
Repoints all four `test_pwt.csv` reads to the copy landed in QuantEcon/data-lectures#98, using the CPython URL form `github.com/QuantEcon/data-lectures/raw/main/lectures/test_pwt.csv` per that repo's AGENTS.md.

One unsplit literal in `pandas.md`; the three reads in `polars.md` each built the URL by concatenation across three source lines and are collapsed to single literals rather than patched (the NEWQDATA precedent — editing the stem line alone leaves the filename appended to a dead path, and a whole-URL grep returns a confident zero against the wrapped form). `pandas.md`'s prose drops the stale `pandas/data/` path prefix; the PWT link is unchanged.

Merging this PR auto-triggers the three sync-translations workflows (they fire on merged PRs touching `lectures/**/*.md`), which is how the repoint reaches lecture-python-programming.zh-cn/.fr/.fa — their pandas and polars lectures fetch the same raw URL live at cell execution. **The local copy is deliberately not deleted here**: deletion follows in a separate PR only after the translations have synced and all four sites republished, because a premature deletion breaks those notebooks at runtime with no stale-serving grace period.

Sweep evidence: after the edit, zero remaining references to this dataset outside the new form — four `data-lectures/raw/main` reads present (positive control), three `test_pwt` mentions per file (read plus prose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

One out-of-scope finding from the sweep, recorded for completeness: `python_advanced_features.md:1173` links this repo's own raw URL for `test_table.csv` in exercise prose — a different file, a prose navigation link rather than a code read, in the class QuantEcon/data-lectures#42 already tracks. Untouched here.
