### PR TITLE
Pin jax to 0.11.0 in CI — jax 0.11.1 hangs the fori_loop cells on CPU

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Install JAX and Numpyro
         shell: bash -l {0}
         run: |
-          pip install -U "jax[cuda13]"
+          # Pinned: jax 0.11.1 (2026-08-17) hangs numpy_vs_numba_vs_jax's
+          # lax.fori_loop cells -- they jit with device=cpu, so the CPU-path
+          # regression bites even on these GPU runners. Context is recorded in
+          # QuantEcon/workspace-lectures#49. With jax already present, the
+          # lecture's unpinned `!pip install quantecon jax` cell is satisfied
+          # and does not upgrade.
+          pip install "jax[cuda13]==0.11.0"
           pip install numpyro
           python scripts/test-jax-install.py
       - name: Check nvidia drivers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,13 @@ jobs:
       - name: Install JAX and Numpyro
         shell: bash -l {0}
         run: |
-          pip install -U "jax[cuda13]"
+          # Pinned: jax 0.11.1 (2026-08-17) hangs numpy_vs_numba_vs_jax's
+          # lax.fori_loop cells -- they jit with device=cpu, so the CPU-path
+          # regression bites even on these GPU runners. Context is recorded in
+          # QuantEcon/workspace-lectures#49. With jax already present, the
+          # lecture's unpinned `!pip install quantecon jax` cell is satisfied
+          # and does not upgrade.
+          pip install "jax[cuda13]==0.11.0"
           pip install numpyro
           python scripts/test-jax-install.py
       - name: Install latex dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,13 @@ jobs:
       - name: Install JAX and Numpyro
         shell: bash -l {0}
         run: |
-          pip install -U "jax[cuda13]"
+          # Pinned: jax 0.11.1 (2026-08-17) hangs numpy_vs_numba_vs_jax's
+          # lax.fori_loop cells -- they jit with device=cpu, so the CPU-path
+          # regression bites even on these GPU runners. Context is recorded in
+          # QuantEcon/workspace-lectures#49. With jax already present, the
+          # lecture's unpinned `!pip install quantecon jax` cell is satisfied
+          # and does not upgrade.
+          pip install "jax[cuda13]==0.11.0"
           pip install numpyro
           python scripts/test-jax-install.py
       - name: Check nvidia drivers


### PR DESCRIPTION
jax/jaxlib 0.11.1 (released 2026-08-17 20:31 UTC) regresses `lax.fori_loop` on the CPU execution path: `numpy_vs_numba_vs_jax` executes in seconds under 0.11.0 and exceeds even an 1800 s cell timeout under 0.11.1 (locally bisected — the same jitted fori_loop hangs with and without the deprecated `device=cpu` argument). This repo is one rebuild away: the unpinned -U install would resolve 0.11.1 at the Monday 2026-08-24 cron cache rebuild, and the lecture jits its jax cells with device=cpu, so the CPU-path regression bites despite the GPU runners (executed in 8.18 s under 0.11.0 on 2026-08-17). numpyro stays unpinned — it was already installed after jax and remains compatible with 0.11.0.

The full evidence chain, family exposure map, and the unpin condition are recorded in QuantEcon/workspace-lectures#49. One PR per repo with this same change; with jax pre-installed, the lecture's unpinned `!pip install quantecon jax` cell is satisfied and does not upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)