### PR TITLE
Pin jax to 0.11.0 in the three execution-* workflows

### DIFF
--- a/.github/workflows/execution-linux.yml
+++ b/.github/workflows/execution-linux.yml
@@ -31,7 +31,14 @@ jobs:
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |
-          pip install "jax[CPU]"
+          # Pinned: jax 0.11.1 (2026-08-17) regresses XLA:CPU execution --
+          # numpy_vs_numba_vs_jax's lax.fori_loop and lax.scan cells go
+          # quadratic in n, so this -W build dies on CellTimeoutError. Matches
+          # the pin already in cache/ci/publish.yml; evidence and the exposure
+          # map are recorded in QuantEcon/workspace-lectures#49. With jax
+          # already present, the lecture's unpinned `!pip install quantecon
+          # jax` cell is satisfied and does not upgrade.
+          pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: bash -l {0}
         run: jb build lectures --path-output=./ -W --keep-going

--- a/.github/workflows/execution-linux.yml
+++ b/.github/workflows/execution-linux.yml
@@ -36,8 +36,9 @@ jobs:
           # quadratic in n, so this -W build dies on CellTimeoutError. Matches
           # the pin already in cache/ci/publish.yml; evidence and the exposure
           # map are recorded in QuantEcon/workspace-lectures#49. With jax
-          # already present, the lecture's unpinned `!pip install quantecon
-          # jax` cell is satisfied and does not upgrade.
+          # already present, the lecture's unpinned
+          # `!pip install quantecon jax` cell is satisfied and does not
+          # upgrade.
           pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: bash -l {0}

--- a/.github/workflows/execution-osx.yml
+++ b/.github/workflows/execution-osx.yml
@@ -31,7 +31,14 @@ jobs:
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |
-          pip install "jax[CPU]"
+          # Pinned: jax 0.11.1 (2026-08-17) regresses XLA:CPU execution --
+          # numpy_vs_numba_vs_jax's lax.fori_loop and lax.scan cells go
+          # quadratic in n, so this -W build dies on CellTimeoutError. Matches
+          # the pin already in cache/ci/publish.yml; evidence and the exposure
+          # map are recorded in QuantEcon/workspace-lectures#49. With jax
+          # already present, the lecture's unpinned `!pip install quantecon
+          # jax` cell is satisfied and does not upgrade.
+          pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: bash -l {0}
         run: jb build lectures --path-output=./ -W --keep-going

--- a/.github/workflows/execution-osx.yml
+++ b/.github/workflows/execution-osx.yml
@@ -36,8 +36,9 @@ jobs:
           # quadratic in n, so this -W build dies on CellTimeoutError. Matches
           # the pin already in cache/ci/publish.yml; evidence and the exposure
           # map are recorded in QuantEcon/workspace-lectures#49. With jax
-          # already present, the lecture's unpinned `!pip install quantecon
-          # jax` cell is satisfied and does not upgrade.
+          # already present, the lecture's unpinned
+          # `!pip install quantecon jax` cell is satisfied and does not
+          # upgrade.
           pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: bash -l {0}

--- a/.github/workflows/execution-win.yml
+++ b/.github/workflows/execution-win.yml
@@ -35,7 +35,14 @@ jobs:
       - name: Install Jax [CPU]
         shell: bash -l {0}
         run: |
-          pip install "jax[CPU]"
+          # Pinned: jax 0.11.1 (2026-08-17) regresses XLA:CPU execution --
+          # numpy_vs_numba_vs_jax's lax.fori_loop and lax.scan cells go
+          # quadratic in n, so this -W build dies on CellTimeoutError. Matches
+          # the pin already in cache/ci/publish.yml; evidence and the exposure
+          # map are recorded in QuantEcon/workspace-lectures#49. With jax
+          # already present, the lecture's unpinned `!pip install quantecon
+          # jax` cell is satisfied and does not upgrade.
+          pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: powershell
         run: jb build lectures --path-output=./ -W --keep-going

--- a/.github/workflows/execution-win.yml
+++ b/.github/workflows/execution-win.yml
@@ -40,8 +40,9 @@ jobs:
           # quadratic in n, so this -W build dies on CellTimeoutError. Matches
           # the pin already in cache/ci/publish.yml; evidence and the exposure
           # map are recorded in QuantEcon/workspace-lectures#49. With jax
-          # already present, the lecture's unpinned `!pip install quantecon
-          # jax` cell is satisfied and does not upgrade.
+          # already present, the lecture's unpinned
+          # `!pip install quantecon jax` cell is satisfied and does not
+          # upgrade.
           pip install "jax[CPU]==0.11.0"
       - name: Build Lectures (+ Execution Checks)
         shell: powershell


### PR DESCRIPTION
Pins jax to `0.11.0` in `execution-linux.yml`, `execution-osx.yml` and `execution-win.yml`, matching the pin already carried by `cache.yml`, `ci.yml` and `publish.yml`.

Closes #619

## Why

The 2026-08-19 pin in #617 covered three of the six workflows in this repo that install jax. The other three install `jax[CPU]` with no constraint and build with `jb build lectures --path-output=./ -W --keep-going`, which executes every lecture — so they hit the jax 0.11.1 regression head-on.

`execution-linux.yml` runs on a daily cron and has been failing since 2026-08-18:

| run | date | log |
| --- | --- | --- |
| 31954622977 | 2026-08-16 | `Successfully installed jax-0.11.0 jaxlib-0.11.0` → `numpy_vs_numba_vs_jax.md: Executed notebook in 4.35 seconds` → success |
| 32041361630 | 2026-08-17 | failure, unrelated — a 429 downloading `setup-miniconda`, jax never installed |
| 32152771492 | 2026-08-18 | `Successfully installed jax-0.11.1 jaxlib-0.11.1` → `CellTimeoutError` |
| 32268416676 | 2026-08-19 | same, at `head_sha 915bfd9f` — i.e. after #617 merged |

`execution-osx.yml` (Mondays) and `execution-win.yml` (Thursdays) run the same unpinned install and the same `-W` build, so they are exposed on their own schedules.

Those two 0.11.0-vs-0.11.1 runs are incidentally the cleanest controlled experiment available for this regression: same workflow, same runner image, only the jax version differing — 4.35 s versus a 600 s timeout.

## Notes on the pin

Pinning jax alone is sufficient. `jax==0.11.0`'s wheel metadata carries `Requires-Dist: jaxlib<=0.11.0,>=0.11.0`, and the pairing is additionally enforced at import in both directions (`jaxlib version 0.11.1 is newer than and incompatible with jax version 0.11.0`), so jaxlib cannot drift even under `--no-deps`.

`jax[CPU]` is kept as-is rather than simplified to `jax`: `cpu` is a declared extra on jax 0.11.0 that adds no requirements, so the bracket is a harmless no-op and dropping it would be an unrelated change.

## On the comment wording

The new comments describe the regression as XLA:CPU execution going quadratic, rather than as a `lax.fori_loop` hang. That is a correction established while validating the settle week (QuantEcon/workspace-lectures#51): re-run on linux x86_64, native linux aarch64 and macOS arm64, the stall is a ~O(n²) blow-up at *runtime* — a stack sample sits in `xla::cpu::ThunkExecutor::ExecuteSequential`, so compilation has already finished — and `lax.scan` regresses identically to `lax.fori_loop`. Measured on linux x86_64 at n=100k/200k/400k: `fori` 6.27 s / 28.49 s / 103.26 s and `scan` 3.83 s / 15.45 s / 60.43 s under 0.11.1, against a flat ~0.05 s under 0.11.0.

The three previously-pinned workflows still carry the older `device=cpu` wording, which has been stale since #563 removed that argument on 2026-06-19. Left alone here to keep this diff to the pin; worth a separate tidy-up.

## Verifying

`workflow_dispatch` is enabled on all three, so a manual dispatch of **Execution Tests [Latest Anaconda, Linux]** on this branch is the direct check — expect `Successfully installed jax-0.11.0` and `numpy_vs_numba_vs_jax.md: Executed notebook in N seconds` at single-digit seconds, with no `CellTimeoutError`.

The unpin condition for all six workflows is tracked on QuantEcon/workspace-lectures#49.
