### PR TITLE
Pin jax in the numpy_vs_numba_vs_jax install cell

### DIFF
--- a/lectures/numpy_vs_numba_vs_jax.md
+++ b/lectures/numpy_vs_numba_vs_jax.md
@@ -45,7 +45,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ---
 tags: [hide-output]
 ---
-!pip install quantecon jax
+!pip install quantecon "jax==0.11.0"
 ```
 
 ```{include} _admonition/gpu.md


### PR DESCRIPTION
Pins the jax install cell in `numpy_vs_numba_vs_jax.md` to `0.11.0`, the version the six workflows already install.

## Why this is not covered by #620

#620 pinned the **build**. It cannot protect the **reader**, and the two paths differ in exactly the way that matters:

| | CI | a reader in Colab |
| --- | --- | --- |
| before the cell runs | jax 0.11.0 already installed by the workflow | clean environment |
| what `!pip install quantecon jax` does | no-op — pip sees the requirement satisfied | resolves the newest release, **0.11.1** |
| then reaches `n = 10_000_000` fori_loop / scan | 5.84 s | does not finish |

The published notebook is live now — `python-programming.quantecon.org/_notebooks/numpy_vs_numba_vs_jax.ipynb` (HTTP 200, 28,740 B) and the generated mirror both still ship the unpinned cell next to `n = 10_000_000` and the CPU-pinned loops.

## Why `==0.11.0` and not `!=0.11.1`

An exclusion looks tidier and self-heals when a fix ships, but it is the wrong choice today: the regression is **still present on jax main**. The nightly `0.11.2.dev20260819` was measured in a container at 96% of 0.11.1's runtime (fori 100k/200k/400k = 6.21 / 25.34 / 100.59 s, against 0.005 s flat under 0.11.0), so a released 0.11.2 would very likely carry the bug and `!=0.11.1` would admit it silently.

Pinning to the exact version CI installs also means readers now execute what the build executes, which is the property the lecture wants anyway — it is a performance comparison, and a reader on a different jax is not measuring the same thing.

## Measurement behind the claim

jax 0.11.1 regresses XLA:CPU execution quadratically. Same container, same script, only the jax version differing (second, post-compilation run, seconds):

| n | 0.11.1 fori | 0.11.1 scan | 0.11.0 fori | 0.11.0 scan |
| --- | --- | --- | --- | --- |
| 100,000 | 6.22 | 3.84 | 0.005 | 0.001 |
| 200,000 | 25.64 | 15.26 | 0.002 | 0.001 |
| 400,000 | 104.97 | 60.36 | 0.005 | 0.003 |

Doubling ratios are 4.12 / 4.10 for fori and 3.98 / 3.96 for scan — O(n²) against an ideal 4.0. A stack sample of the stalled process sits in `xla::cpu::ThunkExecutor::ExecuteSequential`, so compilation has already finished and this is runtime execution. Reproduced on linux x86_64, linux aarch64 and macOS arm64.

## Scope

Only this lecture changes. `jax_intro.md` loops to n=20 and `autodiff.md` has no lax loop, so neither reaches the regime and both keep their unpinned cells.

The same cell exists in the three translations at `numpy_vs_numba_vs_jax.md:64`. Translation sync is `.md`-based, so it should carry this across rather than needing three hand-mirrored PRs — worth confirming on the next sync run.

Lifting this pin belongs with the workflow pins, tracked on QuantEcon/workspace-lectures#49. Nothing upstream to wait on yet: there is no jax release newer than 0.11.1, and no upstream issue describing this regression exists.
